### PR TITLE
Several improvements and fixes 

### DIFF
--- a/llvm/lib/Target/TVM/TVMDictionaryInstrInfo.td
+++ b/llvm/lib/Target/TVM/TVMDictionaryInstrInfo.td
@@ -43,8 +43,8 @@ let mayLoad = 1 in {
       (ins I257:$key, Cell:$dict, I257:$precision), (outs), (ins),
       [(set Cell:$result, I257:$status,
         (int_tvm_dictigetref I257:$key, Cell:$dict, I257:$precision))],
-      "DICTIGET\t$result, $status, $key, $dict, $precision",
-      "DICTIGET NULLSWAPIFNOT", 0xf40d>;
+      "DICTIGETREF\t$result, $status, $key, $dict, $precision",
+      "DICTIGETREF NULLSWAPIFNOT", 0xf40d>;
   defm DICTUGET :
     I<(outs Slice:$result, I257:$status),
       (ins I257:$key, Cell:$dict, I257:$precision), (outs), (ins),

--- a/llvm/lib/Target/TVM/TVMStack.h
+++ b/llvm/lib/Target/TVM/TVMStack.h
@@ -29,6 +29,8 @@
 
 namespace llvm {
 
+static constexpr bool PrintStackInAsm = false;
+
 /// Hold arguments of a machine instruction.
 struct MIArg {
   MIArg(StackVreg Vreg, bool IsKilled) : Vreg(Vreg), IsKilled(IsKilled) {}

--- a/llvm/lib/Target/TVM/TVMStackFixup.cpp
+++ b/llvm/lib/Target/TVM/TVMStackFixup.cpp
@@ -805,7 +805,9 @@ operator()(const std::pair<Change, std::string> &pair) const {
 
   assert(MI && "MI is not generated");
 
-  MFI->addStackModelComment(MI, pair.second);
+  if constexpr (PrintStackInAsm) {
+    MFI->addStackModelComment(MI, pair.second);
+  }
   return MI;
 }
 

--- a/llvm/lib/Target/TVM/TVMStackModel.cpp
+++ b/llvm/lib/Target/TVM/TVMStackModel.cpp
@@ -816,7 +816,7 @@ void TVMStackModel::rewriteToSForm(MachineInstr &MI,
     if (MI.isTerminator())
       MFI->addStackModelComment(MIB.getInstr(), PreTermStackString + " => " +
                                                     TheStack.toString());
-    else
+    else if constexpr (PrintStackInAsm)
       MFI->addStackModelComment(MIB.getInstr(), TheStack.toString());
   }
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/builder.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/builder.hpp
@@ -2,6 +2,7 @@
 
 #include <tvm/cell.hpp>
 #include <tvm/slice.hpp>
+#include <tvm/schema/basics.hpp>
 
 namespace tvm {
 
@@ -16,6 +17,11 @@ public:
   }
   builder& stu(unsigned val, unsigned len) {
     bldr_ = __builtin_tvm_stu(val, bldr_, len);
+    return *this;
+  }
+  template<unsigned bits>
+  builder& stu(uint_t<bits> val) {
+    bldr_ = __builtin_tvm_stu(val.get(), bldr_, uint_t<bits>::bitlen);
     return *this;
   }
   builder& stb(bool val) {

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/cell.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/cell.hpp
@@ -12,9 +12,15 @@ public:
   cell() : cl_((__tvm_cell)__builtin_tvm_pushnull()) {}
   cell(__tvm_cell cl) : cl_(cl) {}
   slice ctos() const { return __builtin_tvm_ctos(cl_); }
+
+  operator bool() const { return !__builtin_tvm_isnull_cell(cl_); }
   bool isnull() const { return __builtin_tvm_isnull_cell(cl_); }
 
   unsigned cdepth() const { return __builtin_tvm_cdepth(cl_); }
+
+  unsigned hash() {
+    return __builtin_tvm_hashcu(cl_);
+  }
 
   __tvm_cell get() const { return cl_; }
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
@@ -202,8 +202,8 @@ __attribute__((tvm_raw_func)) int main_internal(__tvm_cell msg, __tvm_slice msg_
 __attribute__((tvm_raw_func)) GetterResult get_method(int func_id, cell args_pack) {                  \
     return getter_invoke<Contract, IContract, DContract>(func_id, args_pack);                         \
 }                                                                                                     \
-__attribute__((tvm_raw_func)) void main_ticktock(bool is_tock, uint256 address, uint256 balance) {    \
-    main_ticktock_impl<Contract, IContract, DContract>(is_tock, address, balance);                    \
+__attribute__((tvm_raw_func)) void main_ticktock(uint256 balance, uint256 address, bool is_tock) {    \
+    main_ticktock_impl<Contract, IContract, DContract>(balance, address, is_tock);                    \
 }
 
 // Contract class may be simple class, or template with parameter: `bool Internal`.

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/default_support_functions.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/default_support_functions.hpp
@@ -15,6 +15,9 @@
       msg_slice_ = std::get_known<cell>(msg_slice_).ctos();                                                \
     return std::get_known<slice>(msg_slice_);                                                              \
   }                                                                                                        \
+  slice msg_body_;                                                                                         \
+  slice msg_body() { return msg_body_; }                                                                   \
+  void set_msg_body(slice s) { msg_body_ = s; }                                                            \
   std::optional<address> int_sender_;                                                                      \
   Evers int_value_;                                                                                        \
   std::pair<address, Grams> int_sender_and_value() {                                                       \

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/dict.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/dict.hpp
@@ -1,0 +1,169 @@
+#pragma once
+
+#include <tuple>
+
+#include <tvm/cell.hpp>
+#include <tvm/slice.hpp>
+#include <tvm/builder.hpp>
+
+#include <tvm/schema/make_builder.hpp>
+#include <tvm/schema/make_parser.hpp>
+#include <tvm/dictionary.hpp>
+
+namespace tvm {
+
+/**
+ * Just a wrapper class over `dictionary` class with key length as a template
+ * argument. This way we avoid passing the key length to each method.
+ * @tparam KeyLen size in bits of the key
+ */
+template<unsigned KeyLen>
+class Dict {
+public:
+  using key_type = uint_t<KeyLen>;
+
+  struct DictIterator;
+
+  using const_iterator = DictIterator;
+
+  __always_inline Dict() {}
+  __always_inline explicit Dict(cell dict) : dict_{dict} {}
+  __always_inline Dict(dictionary dict) : dict_{dict} {}
+  __always_inline Dict(schema::anydict dict) : dict_{dict} {}
+
+  __always_inline void clear() {
+    dict_.clear();
+  }
+
+  __always_inline void set(unsigned key, slice val) {
+    dict_.dictuset(val, key, KeyLen);
+  }
+  template<unsigned bits>
+  __always_inline void set(uint_t<bits> key, slice val) {
+    set(key.get(), val);
+  }
+
+  __always_inline slice get(unsigned key) {
+    auto [sl, success] = dict_.dictuget(key, KeyLen);
+    return success ? sl : slice();
+  }
+
+  template<unsigned bits>
+  __always_inline slice get(uint_t<bits> key) {
+    return get(key.get());
+  }
+
+  __always_inline slice setget(unsigned key, slice value) {
+    auto [sl, success] = dict_.dictusetget(value, key, KeyLen);
+    return success ? sl : slice();
+  }
+
+  __always_inline cell setgetref(unsigned key, cell value) {
+    auto [cl, success] = dict_.dictusetgetref(value, key, KeyLen);
+    return success ? cl : cell();
+  }
+
+  __always_inline void setref(unsigned key, cell val) {
+    dict_.dictusetref(val, key, KeyLen);
+  }
+
+  __always_inline cell getref(unsigned key) {
+    auto [cl, success] = dict_.dictigetref(key, KeyLen);
+    return success ? cl : cell();
+  }
+
+  __always_inline bool erase(unsigned key) {
+    return dict_.dictudel(key, KeyLen);
+  }
+
+  template<unsigned bits>
+  __always_inline bool erase(uint_t<bits> key) {
+    return erase(key.get());
+  }
+
+  __always_inline std::pair<slice, unsigned> next(unsigned key) {
+    auto [sl, idx, success] = dict_.dictugetnext(key, KeyLen);
+    if (!success) {
+      return {slice::null(), 0};
+    }
+    return {sl, idx};
+  }
+
+  __always_inline const dictionary& dict() const {
+    return dict_;
+  }
+
+  __always_inline dictionary& dict() {
+    return dict_;
+  }
+
+
+  const_iterator begin() const {
+    return const_iterator::create_begin(dict_);
+  }
+  const_iterator end() const {
+    return const_iterator::create_end(dict_);
+  }
+
+  dictionary dict_;
+};
+
+template<unsigned KeyLen>
+struct Dict<KeyLen>::DictIterator: boost::operators<Dict<KeyLen>::DictIterator> {
+  using Pair = std::pair<schema::uint_t<KeyLen>, slice>;
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = slice;
+  using difference_type = int;
+  using pointer = std::pair<schema::uint_t<KeyLen>, slice>*;
+  using reference = std::pair<schema::uint_t<KeyLen>, slice>&;
+
+  dictionary dict_;
+  unsigned idx_;
+  std::optional<slice> sl_;
+
+  __always_inline Pair operator*() const {
+    require(sl_.has_value(), error_code::iterator_overflow);
+    return {schema::uint_t<KeyLen>(idx_), sl_.value()};
+  }
+  __always_inline bool is_end() const {
+    return !sl_;
+  }
+
+  static DictIterator create_begin(dictionary dict) {
+    auto [sl, idx, succ] = dict.dictumin(KeyLen);
+    return DictIterator{{}, dict, idx, succ ? sl : std::optional<slice>()};
+  }
+  static DictIterator create_end(dictionary dict) {
+    return DictIterator{{}, dict, 0, {}};
+  }
+
+  bool operator<(DictIterator x) const { return idx_ < x.idx_; }
+
+  DictIterator& operator++() {
+    auto [sl, next_idx, succ] = dict_.dictugetnext(idx_, KeyLen);
+    if (succ) {
+      sl_ = sl;
+      idx_ = next_idx;
+    } else {
+      sl_.reset();
+    }
+    return *this;
+  }
+  DictIterator& operator--() {
+    auto [sl, prev_idx, succ] = dict_.dictugetprev(idx_, KeyLen);
+    if (succ) {
+      sl_ = sl;
+      idx_ = prev_idx;
+    } else {
+      sl_.reset();
+    }
+    return *this;
+  }
+  bool operator==(DictIterator v) const {
+    bool left_end = is_end();
+    bool right_end = v.is_end();
+    return (left_end && right_end) || (!left_end && !right_end && idx_ == v.idx_);
+  }
+};
+
+} // namespace tvm

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/dict_map.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/dict_map.hpp
@@ -58,15 +58,20 @@ public:
 
   void set_at(unsigned idx, Element val) {
     // increase size if adding new key
-    if constexpr (small_elem) {
-      auto [sl, existing] = base::dict_.dictusetget(build(val).make_slice(), idx, KeyLen);
-      if (!existing)
-        ++base::size_;
+    slice sl;
+    bool existing;
+    if constexpr (std::is_same_v<Element, slice>) {
+      std::tie(sl, existing) = base::dict_.dictusetget(val, idx, KeyLen);
+    } else if constexpr (std::is_same_v<Element, cell>) {
+      std::tie(sl, existing) = base::dict_.dictusetget(val.ctos(), idx, KeyLen);
+    } else if constexpr (small_elem) {
+      std::tie(sl, existing) = base::dict_.dictusetget(build(val).make_slice(), idx, KeyLen);
     } else {
-      auto [sl, existing] = base::dict_.dictusetgetref(build_chain_static(val), idx, KeyLen);
-      if (!existing)
-        ++base::size_;
+      cell c;
+      std::tie(c, existing) = base::dict_.dictusetgetref(build_chain_static(val), idx, KeyLen);
     }
+    if (!existing)
+      ++base::size_;
   }
 
   Element get_at(unsigned idx) const {

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/parser.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/parser.hpp
@@ -10,6 +10,7 @@ class parser {
 public:
   parser(){}
   explicit parser(slice sl) : sl_(sl.get()) {}
+  explicit parser(cell cl) : sl_(cl.ctos()) {}
   explicit parser(__tvm_slice sl) : sl_(sl) {}
   explicit parser(__tvm_cell cell) : sl_(__builtin_tvm_ctos(cell)) {}
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_parser.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/make_parser.hpp
@@ -160,6 +160,15 @@ struct make_parser_impl<cell> {
     return std::tuple(rv, p, ctx);
   }
 };
+template<>
+struct make_parser_impl<slice> {
+  using value_type = slice;
+  template<class _Ctx>
+  __always_inline static std::tuple<optional<value_type>, parser, _Ctx> parse(parser p, _Ctx ctx) {
+    auto rv = value_type{ p.ldrefrtos() };
+    return std::tuple(rv, p, ctx);
+  }
+};
 
 template<>
 struct make_parser_impl<anyval> {
@@ -280,7 +289,13 @@ __always_inline auto parse(parser p, unsigned err_code = error_code::custom_data
 template<class _Tp>
 __always_inline auto parse(slice sl, unsigned err_code = error_code::custom_data_parse_error,
     bool full = false) {
-  return parse<_Tp>(parser(sl));
+  return parse<_Tp>(parser(sl), err_code, full);
+}
+
+template<class _Tp>
+__always_inline auto parse(cell c, unsigned err_code = error_code::custom_data_parse_error,
+                           bool full = false) {
+  return parse<_Tp>(parser(c.ctos()), err_code, full);
 }
 
 template<typename _Tp>

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/slice.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/slice.hpp
@@ -13,14 +13,24 @@ public:
     return __builtin_tvm_pushslice_empty();
   }
 
+  static slice null() {
+    return slice();
+  }
+
   unsigned sbits() const { return __builtin_tvm_sbits(sl_); }
   unsigned srefs() const { return __builtin_tvm_srefs(sl_); }
   std::tuple<unsigned, unsigned> sbitrefs() const {
     return to_std_tuple(__builtin_tvm_sbitrefs(sl_));
   }
+  unsigned depth() const { return __builtin_tvm_sdepth(sl_); }
 
   bool empty() const { return __builtin_tvm_sdempty(sl_); }
   bool srempty() const { return __builtin_tvm_srempty(sl_); }
+
+  operator bool() const { return !isnull(); }
+  bool isnull() const { return __builtin_tvm_isnull_slice(sl_); }
+
+  unsigned hash() { return __builtin_tvm_hashsu(sl_); }
 
   __tvm_slice get() const { return sl_; }
 

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/tuple_list.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/tuple_list.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <tvm/cell.hpp>
+
+namespace tvm {
+
+/**
+ * This class aims for creating lisp-like lists using native tvm_tuple type.
+ * For example, list of [1, 2, 3] will be [1, [2, [3, nil]]].
+ * Mostly it is used in getter methods for returning lists from contracts.
+ * TON getter invoker understands this kind of lists and transform it into
+ * proper form for higher-level languages such as TS or Python.
+ */
+class TupleList {
+public:
+  __always_inline TupleList() : tuple_(__builtin_tvm_nil()) {}
+
+  __always_inline void push(unsigned v) {
+    tuple_ = __builtin_tvm_tpush(tuple_, v);
+  }
+
+  __always_inline void push(cell v) {
+    tuple_ = __builtin_tvm_tpush(tuple_, v.get());
+  }
+
+  __always_inline void push(TupleList v) {
+    tuple_ = __builtin_tvm_tpush(tuple_, v.tuple());
+  }
+
+  template <unsigned bits> __always_inline void push(uint_t<bits> v) {
+    tuple_ = __builtin_tvm_tpush(tuple_, v.get());
+  }
+
+  template <unsigned bits> __always_inline void push(int_t<bits> v) {
+    tuple_ = __builtin_tvm_tpush(tuple_, v.get());
+  }
+
+  __always_inline __tvm_tuple tuple() { return tuple_; }
+
+private:
+  __tvm_tuple tuple_;
+};
+
+} // namespace tvm

--- a/llvm/tools/tvm-build/tvm-build++.py
+++ b/llvm/tools/tvm-build/tvm-build++.py
@@ -107,11 +107,12 @@ cxxflags = ['-O3']
 if args.cxxflags:
   cxxflags += args.cxxflags.split()
 
-pwd = os.path.abspath(os.getcwd()) + '/'
+ir_dump = os.path.join(os.getcwd(), "ir_dump")
+os.makedirs(ir_dump, exist_ok=True)
 
 for filename in input_cpp:
   if args.save_temps:
-    tmp_file = pwd + '1-clang.ll'
+    tmp_file = os.path.join(ir_dump, '1-clang.ll')
   else:
     _, tmp_file = tempfile.mkstemp()
   execute([os.path.join(tvm_llvm_bin, 'clang++'), '-target', 'tvm'] +
@@ -135,7 +136,7 @@ for filename in input_ll:
   input_bc += [tmp_file]
 
 if args.save_temps:
-  bitcode = pwd + '2-llvm-link.ll'
+  bitcode = os.path.join(ir_dump, '2-llvm-link.ll')
 else:
   _, bitcode = tempfile.mkstemp()
 execute([os.path.join(tvm_llvm_bin, 'llvm-link')] + input_bc +
@@ -148,7 +149,7 @@ if args.inline_loads_stores:
   replace_loads_stores = ['-tvm-load-store-replace']
 
 if args.save_temps:
-  bitcode_int = pwd + '3-opt.ll'
+  bitcode_int = os.path.join(ir_dump, '3-opt.ll')
 else:
   _, bitcode_int = tempfile.mkstemp()
 execute([os.path.join(tvm_llvm_bin, 'opt'), bitcode, '-S', '-o', bitcode_int] +
@@ -161,14 +162,14 @@ else:
   opt_flags = ['-O3']
 
 if args.save_temps:
-  bitcode_opt = pwd + '4-opt_O3.ll'
+  bitcode_opt = os.path.join(ir_dump, '4-opt_O3.ll')
 else:
   _, bitcode_opt = tempfile.mkstemp()
 execute([os.path.join(tvm_llvm_bin, 'opt')] + opt_flags + ['-S', bitcode_int, '-o',
   bitcode_opt], args.verbose)
 
 if args.save_temps:
-  asm = pwd + '5-llc.asm'
+  asm = os.path.join(ir_dump, '5-llc.asm')
 else:
   _, asm = tempfile.mkstemp()
 execute([os.path.join(tvm_llvm_bin, 'llc'), '-march', 'tvm', bitcode_opt,


### PR DESCRIPTION
- Add knob to disable stack printing in asm output
- Fix `DICTIGETREF` record
- build++.py generates temporary files to the separate directory
- Introduce `Dict` class, which is simple wrapper over `dictionary` with predefined key length
- Introduce `TupleList` class that implements simple linked list via tvm tuple
- SDK improvements and fixes