### PR TITLE
Remove library from data structs

### DIFF
--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/contract.hpp
@@ -141,9 +141,8 @@ uint256 tvm_state_init_hash(uint256 code_hash, uint256 data_hash, uint16 code_de
   b.stu(2, 8) // amount of refs - code + data = 2
    .stu(1, 8) // data bitlen descriptor = ((bitlen / 8) << 1) + ((bitlen % 8) ? 1 : 0)
    // data bits: optional<..> split_depth, optional<..> special,
-   // optional<ref> code, optional<ref> data,
-   // optional<..> library ==> b00110
-   .stu(0b00110, 5)
+   // optional<ref> code, optional<ref> data ==> b0011
+   .stu(0b0011, 4)
    .stu(0b100, 3) // completion tag b100
    .stu(code_depth.get(), 16)
    .stu(data_depth.get(), 16)

--- a/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/message.hpp
+++ b/llvm/projects/ton-compiler/cpp-sdk/tvm/schema/message.hpp
@@ -106,7 +106,6 @@ struct StateInit {
   optional<TickTock> special;
   optional<cell> code;
   optional<cell> data;
-  optional<cell> library;
 };
 
 template<typename X>


### PR DESCRIPTION
We can't use library in our vm, thats why we can remove them from code and scheme.

This PR connected with https://github.com/NilFoundation/dbms/pull/640